### PR TITLE
Correct template-setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,10 +57,16 @@ You can now use `just deploy` to run the `examples/deploy.rs` script. The script
 
 ### Generating Typescript Client Code
 
-To generate the typescript client code for the contract you can run `just ts-codegen`. This will generate the code in the `ts-sdk/src` directory. You can then import the generated code in your frontend application.
+Before proceeding you need to install the required dependencies for the typescript client code generation.
 
-To publish the Typescript sdk, first change the name and version in the `ts-sdk/package.json` file. Then run `just ts-publish`. This will publish the sdk to npm.
+```bash
+cd typescript
+npm install
+```
 
+To generate the typescript client code for the contract you can run `just ts-codegen`. This will generate the code in the `typescript/src` directory. You can then import the generated code in your frontend application.
+
+To publish the Typescript sdk, first change the name and version in the `typescript/package.json` file. Then run `just ts-publish`. This will publish the sdk to npm.
 
 ### Publishing Module Schemas
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The setup script will add our Github CI repo to the repo.
 
 ## Using the Justfile
 
-This repository comes with a `justfile`, which is a handy task runner that helps with building, testing, and deploying your Abstract app module.
+This repository comes with a [`justfile`](https://github.com/casey/just), which is a handy task runner that helps with building, testing, and deploying your Abstract app module.
 
 ### Installing Tools
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ chmod +x ./template-setup.sh
 ./template-setup.sh
 ```
 
-The setup script will ask you for a name that will replace the "template" names in the repo. It also adds our Github CI repo to the repo.
+The setup script will add our Github CI repo to the repo.
 
 ## Using the Justfile
 

--- a/justfile
+++ b/justfile
@@ -49,11 +49,11 @@ schema:
 
 # Generate the typescript client for the app contract
 ts-codegen: schema
-  (cd ts-sdk && npm run codegen)
+  (cd typescript && npm run codegen)
 
 # Publish the typescript sdk
 ts-publish: ts-codegen
-  (cd ts-sdk && npm publish --access public)
+  (cd typescript && npm publish --access public)
 
 # Generate the schemas for this app and publish them to the schemas repository for access in the Abstract frontend
 publish-schemas namespace name version: schema

--- a/src/handlers/instantiate.rs
+++ b/src/handlers/instantiate.rs
@@ -15,6 +15,6 @@ pub fn instantiate_handler(
 
     CONFIG.save(deps.storage, &config)?;
 
-    // Example reply that doesn't do anything
+    // Example instantiation that doesn't do anything
     Ok(Response::new())
 }

--- a/template-setup.sh
+++ b/template-setup.sh
@@ -3,10 +3,9 @@
 # Add the CI to this repo
 git remote add ci https://github.com/AbstractSDK/rust-ci
 git fetch ci
-git merge ci/main --squash
+git merge ci/main --squash --allow-unrelated-histories
 
 mv example.env .env
 
-rm ./README.md
 # Delete this script after running
 rm -- "$0"

--- a/template-setup.sh
+++ b/template-setup.sh
@@ -3,7 +3,7 @@
 # Add the CI to this repo
 git remote add ci https://github.com/AbstractSDK/rust-ci
 git fetch ci
-git merge ci/main --squash --allow-unrelated-histories
+git merge ci/main --allow-unrelated-histories
 
 mv example.env .env
 

--- a/template-setup.sh
+++ b/template-setup.sh
@@ -7,5 +7,6 @@ git merge ci/main --squash
 
 mv example.env .env
 
+rm ./README.md
 # Delete this script after running
 rm -- "$0"


### PR DESCRIPTION
This PR aims at correcting the template-setup file

1. You should allow unrelated hstories for merging with any repo
2. You should keep the README, otherwise the user will just delete it un-intentionally