### PR TITLE
Fix migratemsg type

### DIFF
--- a/schema/migrate_msg.json
+++ b/schema/migrate_msg.json
@@ -27,8 +27,8 @@
   "additionalProperties": false,
   "definitions": {
     "AppMigrateMsg": {
-      "type": "string",
-      "enum": []
+      "type": "object",
+      "additionalProperties": false
     },
     "BaseMigrateMsg": {
       "type": "object",

--- a/schema/module-schema.json
+++ b/schema/module-schema.json
@@ -1,6 +1,6 @@
 {
   "contract_name": "module-schema",
-  "contract_version": "0.20.0",
+  "contract_version": "0.21.0",
   "idl_version": "1.0.0",
   "instantiate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
@@ -113,8 +113,8 @@
   "migrate": {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "MigrateMsg",
-    "type": "string",
-    "enum": []
+    "type": "object",
+    "additionalProperties": false
   },
   "sudo": null,
   "responses": {

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -78,7 +78,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Returns the admin.",
+          "description": "Returns the admin. Returns [`AdminResponse`]",
           "type": "object",
           "required": [
             "base_admin"
@@ -92,7 +92,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Returns module data",
+          "description": "Returns module data Returns [`ModuleDataResponse`]",
           "type": "object",
           "required": [
             "module_data"
@@ -106,7 +106,7 @@
           "additionalProperties": false
         },
         {
-          "description": "Returns top level owner",
+          "description": "Returns top level owner Returns [`TopLevelOwnerResponse`]",
           "type": "object",
           "required": [
             "top_level_owner"

--- a/schema/raw/migrate.json
+++ b/schema/raw/migrate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "MigrateMsg",
-  "type": "string",
-  "enum": []
+  "type": "object",
+  "additionalProperties": false
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -40,7 +40,7 @@ pub enum AppQueryMsg {
 }
 
 #[cosmwasm_schema::cw_serde]
-pub enum AppMigrateMsg {}
+pub struct AppMigrateMsg {}
 
 #[cosmwasm_schema::cw_serde]
 pub struct ConfigResponse {}


### PR DESCRIPTION
This PR fixes type of MigrateMsg which is not possible to construct(or serialize/deserialize) by changing it to struct