### PR TITLE
0.26.0 version upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ thiserror = { version = "1.0.64" }
 schemars = "0.8"
 cw-asset = { version = "4.0.0" }
 
-abstract-app = { version = "0.24.1-beta.2" }
-abstract-adapter = { version = "0.24.1-beta.2" }
-abstract-standalone = { version = "0.24.1-beta.2" }
-abstract-interface = { version = "0.24.1-beta.2" }
-abstract-client = { version = "0.24.1-beta.2" }
+abstract-app = { version = "0.25.0", git = "https://github.com/AbstractSDK/abstract", tag = "v0.25.0" }
+abstract-adapter = { version = "0.25.0", git = "https://github.com/AbstractSDK/abstract", tag = "v0.25.0" }
+abstract-standalone = { version = "0.25.0", git = "https://github.com/AbstractSDK/abstract", tag = "v0.25.0" }
+abstract-interface = { version = "0.25.0", git = "https://github.com/AbstractSDK/abstract", tag = "v0.25.0" }
+abstract-client = { version = "0.25.0", git = "https://github.com/AbstractSDK/abstract", tag = "v0.25.0" }
 cw-orch = { version = "0.25.1" }
 
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,11 +22,11 @@ thiserror = { version = "1.0.64" }
 schemars = "0.8"
 cw-asset = { version = "4.0.0" }
 
-abstract-app = { version = "0.25.0", git = "https://github.com/AbstractSDK/abstract", tag = "v0.25.0" }
-abstract-adapter = { version = "0.25.0", git = "https://github.com/AbstractSDK/abstract", tag = "v0.25.0" }
-abstract-standalone = { version = "0.25.0", git = "https://github.com/AbstractSDK/abstract", tag = "v0.25.0" }
-abstract-interface = { version = "0.25.0", git = "https://github.com/AbstractSDK/abstract", tag = "v0.25.0" }
-abstract-client = { version = "0.25.0", git = "https://github.com/AbstractSDK/abstract", tag = "v0.25.0" }
+abstract-app = { version = "0.26.0" }
+abstract-adapter = { version = "0.26.0" }
+abstract-standalone = { version = "0.26.0" }
+abstract-interface = { version = "0.26.0" }
+abstract-client = { version = "0.26.0" }
 cw-orch = { version = "0.25.1" }
 
 lazy_static = "1.4.0"

--- a/contracts/{{adapter_name}}/Cargo.toml
+++ b/contracts/{{adapter_name}}/Cargo.toml
@@ -58,5 +58,5 @@ env_logger = { workspace = true, optional = true }
 
 [dev-dependencies]
 {{adapter_name | kebab_case}} = { workspace = true }
-abstract-client = { workspace = true }
+abstract-client = { workspace = true, features = ["test-utils"] }
 abstract-adapter = { workspace = true, features = ["test-utils"] }

--- a/contracts/{{adapter_name}}/src/api.rs
+++ b/contracts/{{adapter_name}}/src/api.rs
@@ -60,7 +60,7 @@ impl<'a, T: {{adapter_name | upper_camel_case}}Api> {{adapter_name | upper_camel
 }
 
 /// Queries
-impl<'a, T: {{adapter_name | upper_camel_case}}Api> {{adapter_name | upper_camel_case}}<'a, T> {
+impl<T: {{adapter_name | upper_camel_case}}Api> {{adapter_name | upper_camel_case}}<'_, T> {
     /// Query your adapter via message type
     pub fn query<R: DeserializeOwned>(&self, query_msg: {{adapter_name | upper_camel_case}}QueryMsg) -> AbstractSdkResult<R> {
         let adapters = self.base.adapters(self.deps);

--- a/contracts/{{adapter_name}}/src/api.rs
+++ b/contracts/{{adapter_name}}/src/api.rs
@@ -17,7 +17,7 @@ use cosmwasm_std::{CosmosMsg, Deps, Uint128};
 /// Interact with your adapter in other modules.
 pub trait {{adapter_name | upper_camel_case}}Api: AccountIdentification + Dependencies + ModuleIdentification {
     /// Construct a new adapter interface.
-    fn {{adapter_name | snake_case}}<'a>(&'a self, deps: Deps<'a>) -> {{adapter_name | upper_camel_case}}<Self> {
+    fn {{adapter_name | snake_case}}<'a>(&'a self, deps: Deps<'a>) -> {{adapter_name | upper_camel_case}}<'a, Self> {
         {{adapter_name | upper_camel_case}} {
             base: self,
             deps,

--- a/contracts/{{adapter_name}}/src/handlers/execute.rs
+++ b/contracts/{{adapter_name}}/src/handlers/execute.rs
@@ -28,10 +28,10 @@ pub fn execute_handler(
 }
 
 /// Update the configuration of the adapter
-fn update_config(deps: DepsMut, env: Env, _msg_info: MessageInfo, module: {{adapter_name | upper_camel_case}}) -> AdapterResult {
+fn update_config(deps: DepsMut, _env: Env, _msg_info: MessageInfo, module: {{adapter_name | upper_camel_case}}) -> AdapterResult {
     // Only admin(namespace owner) can change recipient address
     let namespace = module
-        .module_registry(deps.as_ref(), &env)?
+        .module_registry(deps.as_ref())?
         .query_namespace(Namespace::new({{project-name | shouty_snake_case}}_NAMESPACE)?)?;
 
     // unwrap namespace, since it's unlikely to have unclaimed namespace as this adapter installed
@@ -46,8 +46,8 @@ fn update_config(deps: DepsMut, env: Env, _msg_info: MessageInfo, module: {{adap
     Ok(module.response("update_config"))
 }
 
-fn set_status(deps: DepsMut, env: Env, module: {{adapter_name | upper_camel_case}}, status: String) -> AdapterResult {
-    let account_registry = module.account_registry(deps.as_ref(), &env)?;
+fn set_status(deps: DepsMut, _env: Env, module: {{adapter_name | upper_camel_case}}, status: String) -> AdapterResult {
+    let account_registry = module.account_registry(deps.as_ref())?;
 
     let account_id = account_registry.account_id(module.target()?)?;
     STATUS.save(deps.storage, &account_id, &status)?;

--- a/contracts/{{adapter_name}}/tests/integration.rs
+++ b/contracts/{{adapter_name}}/tests/integration.rs
@@ -26,7 +26,7 @@ impl TestEnv<MockBech32> {
         let namespace = Namespace::new({{project-name | shouty_snake_case}}_NAMESPACE)?;
 
         // You can set up Abstract with a builder.
-        let abs_client = AbstractClient::builder(mock).build_mock()?;
+        let abs_client = AbstractClient::builder(mock).build()?;
         // The adapter supports setting balances for addresses and configuring ANS.
         abs_client.set_balance(&sender, &coins(123, "ucosm"))?;
 

--- a/contracts/{{app_name}}/Cargo.toml
+++ b/contracts/{{app_name}}/Cargo.toml
@@ -58,5 +58,5 @@ env_logger = { workspace = true, optional = true }
 
 [dev-dependencies]
 {{app_name | kebab_case}} = { workspace = true }
-abstract-client = { workspace = true }
+abstract-client = { workspace = true, features = ["test-utils"] }
 abstract-app = { workspace = true, features = ["test-utils"] }

--- a/contracts/{{app_name}}/tests/integration.rs
+++ b/contracts/{{app_name}}/tests/integration.rs
@@ -27,7 +27,7 @@ impl TestEnv<MockBech32> {
         let namespace = Namespace::new({{project-name | shouty_snake_case}}_NAMESPACE)?;
 
         // You can set up Abstract with a builder.
-        let abs_client = AbstractClient::builder(mock).build_mock()?;
+        let abs_client = AbstractClient::builder(mock).build()?;
         // The app supports setting balances for addresses and configuring ANS.
         abs_client.set_balance(&sender, &coins(123, "ucosm"))?;
 

--- a/contracts/{{standalone_name}}/Cargo.toml
+++ b/contracts/{{standalone_name}}/Cargo.toml
@@ -58,5 +58,5 @@ env_logger = { workspace = true, optional = true }
 
 [dev-dependencies]
 {{standalone_name | kebab_case}} = { path = "." }
-abstract-client = { workspace = true }
+abstract-client = { workspace = true, features = ["test-utils"] }
 abstract-standalone = { workspace = true, features = ["test-utils"] }

--- a/contracts/{{standalone_name}}/src/contract.rs
+++ b/contracts/{{standalone_name}}/src/contract.rs
@@ -44,7 +44,7 @@ pub fn execute(
         {{standalone_name | upper_camel_case}}ExecuteMsg::Reset { count } => reset(deps, env, info, count, standalone),
         {{standalone_name | upper_camel_case}}ExecuteMsg::IbcCallback(msg) => {
             let binding = {{standalone_name | shouty_snake_case}};
-            let ibc_client = binding.ibc_client(deps.as_ref(), &env);
+            let ibc_client = binding.ibc_client(deps.as_ref());
 
             let ibc_client_addr = ibc_client.module_address()?;
             if info.sender.ne(&ibc_client_addr) {

--- a/contracts/{{standalone_name}}/tests/integration.rs
+++ b/contracts/{{standalone_name}}/tests/integration.rs
@@ -8,7 +8,7 @@ use {{standalone_name | snake_case}}::{
 };
 
 use abstract_client::{AbstractClient, Application, Environment};
-use abstract_standalone::{objects::namespace::Namespace};
+use abstract_standalone::objects::namespace::Namespace;
 use cosmwasm_std::coins;
 // Use prelude to get all the necessary imports
 use cw_orch::{anyhow, prelude::*};
@@ -27,7 +27,7 @@ impl TestEnv<MockBech32> {
         let namespace = Namespace::new({{project-name | shouty_snake_case}}_NAMESPACE)?;
 
         // You can set up Abstract with a builder.
-        let abs_client = AbstractClient::builder(mock).build_mock()?;
+        let abs_client = AbstractClient::builder(mock).build()?;
         // The standalone supports setting balances for addresses and configuring ANS.
         abs_client.set_balance(&sender, &coins(123, "ucosm"))?;
 


### PR DESCRIPTION
We published 0.26.0 to crates, so we can use that instead of git deps now :partying_face:

Initially pushed into `believathon` branch, but was not sure if it's actively used for something